### PR TITLE
Enable package registry proxy for prefetch-dependencies

### DIFF
--- a/.tekton/submariner-fbc-4-16-pull-request.yaml
+++ b/.tekton/submariner-fbc-4-16-pull-request.yaml
@@ -213,6 +213,8 @@ spec:
         value: $(params.output-image).prefetch
       - name: ociArtifactExpiresAfter
         value: $(params.image-expires-after)
+      - name: enable-package-registry-proxy
+        value: "true"
       runAfter:
       - run-opm-command
       taskRef:

--- a/.tekton/submariner-fbc-4-16-push.yaml
+++ b/.tekton/submariner-fbc-4-16-push.yaml
@@ -210,6 +210,8 @@ spec:
         value: $(params.output-image).prefetch
       - name: ociArtifactExpiresAfter
         value: $(params.image-expires-after)
+      - name: enable-package-registry-proxy
+        value: "true"
       runAfter:
       - run-opm-command
       taskRef:

--- a/.tekton/submariner-fbc-4-17-pull-request.yaml
+++ b/.tekton/submariner-fbc-4-17-pull-request.yaml
@@ -213,6 +213,8 @@ spec:
         value: $(params.output-image).prefetch
       - name: ociArtifactExpiresAfter
         value: $(params.image-expires-after)
+      - name: enable-package-registry-proxy
+        value: "true"
       runAfter:
       - run-opm-command
       taskRef:

--- a/.tekton/submariner-fbc-4-17-push.yaml
+++ b/.tekton/submariner-fbc-4-17-push.yaml
@@ -210,6 +210,8 @@ spec:
         value: $(params.output-image).prefetch
       - name: ociArtifactExpiresAfter
         value: $(params.image-expires-after)
+      - name: enable-package-registry-proxy
+        value: "true"
       runAfter:
       - run-opm-command
       taskRef:

--- a/.tekton/submariner-fbc-4-18-pull-request.yaml
+++ b/.tekton/submariner-fbc-4-18-pull-request.yaml
@@ -213,6 +213,8 @@ spec:
         value: $(params.output-image).prefetch
       - name: ociArtifactExpiresAfter
         value: $(params.image-expires-after)
+      - name: enable-package-registry-proxy
+        value: "true"
       runAfter:
       - run-opm-command
       taskRef:

--- a/.tekton/submariner-fbc-4-18-push.yaml
+++ b/.tekton/submariner-fbc-4-18-push.yaml
@@ -210,6 +210,8 @@ spec:
         value: $(params.output-image).prefetch
       - name: ociArtifactExpiresAfter
         value: $(params.image-expires-after)
+      - name: enable-package-registry-proxy
+        value: "true"
       runAfter:
       - run-opm-command
       taskRef:

--- a/.tekton/submariner-fbc-4-19-pull-request.yaml
+++ b/.tekton/submariner-fbc-4-19-pull-request.yaml
@@ -213,6 +213,8 @@ spec:
         value: $(params.output-image).prefetch
       - name: ociArtifactExpiresAfter
         value: $(params.image-expires-after)
+      - name: enable-package-registry-proxy
+        value: "true"
       runAfter:
       - run-opm-command
       taskRef:

--- a/.tekton/submariner-fbc-4-19-push.yaml
+++ b/.tekton/submariner-fbc-4-19-push.yaml
@@ -210,6 +210,8 @@ spec:
         value: $(params.output-image).prefetch
       - name: ociArtifactExpiresAfter
         value: $(params.image-expires-after)
+      - name: enable-package-registry-proxy
+        value: "true"
       runAfter:
       - run-opm-command
       taskRef:

--- a/.tekton/submariner-fbc-4-20-pull-request.yaml
+++ b/.tekton/submariner-fbc-4-20-pull-request.yaml
@@ -199,6 +199,8 @@ spec:
         value: $(params.output-image).prefetch
       - name: ociArtifactExpiresAfter
         value: $(params.image-expires-after)
+      - name: enable-package-registry-proxy
+        value: "true"
       runAfter:
       - run-opm-command
       taskRef:

--- a/.tekton/submariner-fbc-4-20-push.yaml
+++ b/.tekton/submariner-fbc-4-20-push.yaml
@@ -196,6 +196,8 @@ spec:
         value: $(params.output-image).prefetch
       - name: ociArtifactExpiresAfter
         value: $(params.image-expires-after)
+      - name: enable-package-registry-proxy
+        value: "true"
       runAfter:
       - run-opm-command
       taskRef:

--- a/.tekton/submariner-fbc-4-21-pull-request.yaml
+++ b/.tekton/submariner-fbc-4-21-pull-request.yaml
@@ -198,6 +198,8 @@ spec:
         value: $(params.output-image).prefetch
       - name: ociArtifactExpiresAfter
         value: $(params.image-expires-after)
+      - name: enable-package-registry-proxy
+        value: "true"
       runAfter:
       - run-opm-command
       taskRef:

--- a/.tekton/submariner-fbc-4-21-push.yaml
+++ b/.tekton/submariner-fbc-4-21-push.yaml
@@ -195,6 +195,8 @@ spec:
         value: $(params.output-image).prefetch
       - name: ociArtifactExpiresAfter
         value: $(params.image-expires-after)
+      - name: enable-package-registry-proxy
+        value: "true"
       runAfter:
       - run-opm-command
       taskRef:


### PR DESCRIPTION
Fix prefetch_dependencies.package_registry_proxy_enabled EC violation that became effective 2026-05-13, blocking FBC prod releases.